### PR TITLE
Non null terminated strings error

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -223,7 +223,7 @@ local function load_cell(file, var)
 end
 
 local function load_string(file, var)
-  return var.data~=nil and ffi.string(var.data) or ''
+  return var.data~=nil and ffi.string(var.data,var.nbytes) or ''
 end
 
 function mat_read_variable(file, var) 


### PR DESCRIPTION
When loading strings from a matlab file, you can sometimes get weird characters.  This happens because matio strings aren't null-terminated and ffi.string assumes null-terminated strings.