### PR TITLE
Fixed brew instructions for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ If you are manually compiling matio from scratch (instead of using your package 
 
 ```sh
 # OSX
-brew install libmatio
+brew install homebrew/science/libmatio
 
 # Ubuntu
 sudo apt-get install libmatio2


### PR DESCRIPTION
````BASH
==> Searching taps...
This formula was found in a tap:
homebrew/science/libmatio
To install it, run:
  brew install homebrew/science/libmatio
````

Fixed instructions accordingly.