### PR TITLE
updated installation for ubuntu 18.04 (as described in issue #29)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,13 @@ If you are manually compiling matio from scratch (instead of using your package 
 # OSX
 brew install homebrew/science/libmatio
 
-# Ubuntu
+# Ubuntu <= 16.04
 sudo apt-get install libmatio2
+
+# Ubuntu 18.04
+sudo apt-get install libmatio4
+ln -s /usr/lib/x86_64-linux-gnu/libmatio.so.4 /usr/lib/x86_64-linux-gnu/libmatio.so
+
 ```
 
 


### PR DESCRIPTION
Ubuntu 18.04 uses `libmatio4` instead of `libmatio2`. To use the new lib version, we also need to create a symbolic link like this: `ln -s /usr/lib/x86_64-linux-gnu/libmatio.so.4 /usr/lib/x86_64-linux-gnu/libmatio.so`  (full error description in Issue #29 )

I added an installation section for Ubuntu 18.04 to your Readme.